### PR TITLE
Supporting non latin password for getting token

### DIFF
--- a/javatar-security-spring-boot-starter/src/main/java/pro/javatar/security/starter/config/model/StorageImpl.java
+++ b/javatar-security-spring-boot-starter/src/main/java/pro/javatar/security/starter/config/model/StorageImpl.java
@@ -1,7 +1,6 @@
 package pro.javatar.security.starter.config.model;
 
 import pro.javatar.security.api.config.SecurityConfig;
-import pro.javatar.security.starter.config.SecurityConfigImpl;
 
 /**
  * @author Borys Zora

--- a/security-filter/src/main/java/pro/javatar/security/oidc/client/OAuthClient.java
+++ b/security-filter/src/main/java/pro/javatar/security/oidc/client/OAuthClient.java
@@ -35,6 +35,7 @@ import pro.javatar.security.oidc.utils.StringUtils;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
+import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
@@ -158,7 +159,7 @@ public class OAuthClient {
             requestBase.addHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_FORM_URLENCODED_VALUE);
 
             logger.debug("Query parameters: {}", maskedParams(params));
-            requestBase.setEntity(new UrlEncodedFormEntity(params));
+            requestBase.setEntity(new UrlEncodedFormEntity(params, StandardCharsets.UTF_8));
 
             httpResponse = httpClient.execute(requestBase);
 


### PR DESCRIPTION
User is not able to login (obtain token) with password like "汉字123zxc+0".